### PR TITLE
feat: add minimumReleaseAge configuration to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "config:js-lib", ":automergePatch", ":configMigration"],
+  "minimumReleaseAge": "5 days",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
## Summary

- Add `minimumReleaseAge: "5 days"` configuration to renovate.json
- This ensures all packages have been available for 5 days before being updated by Renovate
- Helps avoid potential issues with newly released versions

## Changes

- Updated renovate.json to include the `minimumReleaseAge` setting

🤖 Generated with [Claude Code](https://claude.ai/code)